### PR TITLE
Modify xmodem implementation to resend a block on *any* response other than ACK.

### DIFF
--- a/src/xmodem.c
+++ b/src/xmodem.c
@@ -309,20 +309,16 @@ static int xmodem_go(up_context_t  *ctx,
         send_buffer(ctx, buffer, use_crc16);
 
         /* Wait to see if the 8148 liked it */
-        do
-        {
-            rx_byte = get_byte(ctx);
-            if (rx_byte < 0)
-                return rx_byte;
-        } while (rx_byte != XMODEM_ACK && rx_byte != XMODEM_NAK);
-
+        rx_byte = get_byte(ctx);
+        if (rx_byte < 0)
+            return rx_byte;
 
 #if DEBUG0
         printf("rx_byte = 0x%02x \n", rx_byte);
 #endif
 
-
-        if (rx_byte == XMODEM_NAK)
+        /* Consider anything other than ACK as requiring a resend */
+        if (rx_byte != XMODEM_ACK)
             continue;  /* Resend the same buffer */
 
         if (image_bytes != 0)


### PR DESCRIPTION
Previously the xmodem implementation would wait indefinitely for either ACK or NAK in response to a block, discarding any other characters.  (The xmodem documentation is silent on what an implementation should do given neither ACK nor NAK.)

Now treat any response other than ACK as if it were a NAK, resending the block.  This is intended to improve robustness.  Clients should ignore any previously received block that is resent.

(In particular, this change has been found effective at working around an issue on some particular hardware prone to restarting during xmodem boot while the power supply became stable.)